### PR TITLE
Add build job to CI

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -10,8 +10,10 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - name: Install tools
-        run: sudo apt install clang-format
+      - name: install tools
+        run: |
+          sudo apt update
+          sudo apt install -y clang-format
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
         with:
@@ -20,9 +22,31 @@ jobs:
         with:
           path: ~/.cache/pre-commit
           key: ${{runner.os}}-pre-commit
-      - name: Install dependencies
+      - name: install pre-commit
         run: |
           python -m pip install --upgrade pip
           pip install pre-commit
       - name: Run pre-commit
         run: pre-commit run --all-files
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: install tools
+        run: |
+          sudo apt update
+          sudo apt install -y cmake
+      - uses: carlosperate/arm-none-eabi-gcc-action@v1
+        with:
+          release: latest
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: init sdk
+        run: git -C vendor/pico-sdk submodule update --init
+      - id: build-release
+        name: build release
+        run: |
+          mkdir build-release
+          cd build-release
+          cmake ../
+          make

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ repos:
         args:
           - --fix=lf
       - id: end-of-file-fixer
+      - id: check-yaml
   - repo: local
     hooks:
       - id: clang-format

--- a/README.md
+++ b/README.md
@@ -11,3 +11,8 @@ Contains all third party code in the form of git submodules. This includes:
 ### `pico`
 All RP2040 dependent code is included in this directory. Basically
 all peripheral access. It also includes configuration for RTOS.
+
+## Building
+This is a standard CMake project and can be built as such. The project is built and tested with
+ARM GCC. Logging macros depend on `__FILE_NAME__` so the compiler must define this macro. GCC
+versions below 12.3 don't define it and won't be able to build the project.


### PR DESCRIPTION
A new job called 'build' has been added to run in Github's CI. This
compiles all sources with gcc-arm and verifies the project is buildable.

pre-commit will also check valid yaml files from now on since all
github actions files are yaml.