### PR TITLE
Get UID for board

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -50,3 +50,16 @@ jobs:
           cd build-release
           cmake ../
           make
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: build host
+        run: |
+          cmake -DHOST_BUILD=YES -B cmake-build-host
+          make -C cmake-build-host
+      - name: run tests
+        run: |
+          make -C cmake-build-host ARGS="-V" test

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "vendor/ugfx"]
 	path = vendor/ugfx
 	url = https://git.ugfx.io/uGFX/ugfx.git
+[submodule "vendor/googletest"]
+	path = vendor/googletest
+	url = https://github.com/google/googletest.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,10 @@
 cmake_minimum_required(VERSION 3.20)
-set(FREERTOS_PORT GCC_RP2040)
-set(PICO_BOARD pico_w)
-include(vendor/pico-sdk/pico_sdk_init.cmake)
-include(vendor/free-rtos/portable/ThirdParty/GCC/RP2040/FreeRTOS_Kernel_import.cmake)
+if (NOT DEFINED HOST_BUILD)
+    set(FREERTOS_PORT GCC_RP2040)
+    set(PICO_BOARD pico_w)
+    include(vendor/pico-sdk/pico_sdk_init.cmake)
+    include(vendor/free-rtos/portable/ThirdParty/GCC/RP2040/FreeRTOS_Kernel_import.cmake)
+endif()
 
 project(pcroast
     VERSION 0.2.0
@@ -31,7 +33,17 @@ add_compile_definitions("WIFI_TIMEOUT=${WIFI_TIMEOUT}")
 add_compile_definitions("WIFI_SSID=\"${WIFI_SSID}\"")
 add_compile_definitions("WIFI_PSK=\"${WIFI_PSK}\"")
 
+include_directories(include)
+add_subdirectory(src)
 
-pico_sdk_init()
-include_directories(pico include vendor/ugfx/drivers/gdisp/ST7735)
-add_subdirectory(pico)
+if (NOT DEFINED HOST_BUILD)
+    pico_sdk_init()
+    include_directories(pico include vendor/ugfx/drivers/gdisp/ST7735)
+    add_subdirectory(pico)
+endif()
+
+if (DEFINED HOST_BUILD)
+    add_subdirectory(vendor/googletest)
+    enable_testing()
+    add_subdirectory(tests)
+endif()

--- a/README.md
+++ b/README.md
@@ -8,12 +8,33 @@ Contains all third party code in the form of git submodules. This includes:
 * pico-sdk: Provides libraries to write code for RP2040 processors
 * free-rtos: Real time operating system to keep track of all the control tasks performed by the system
 * ugfx: Graphics library used for the display
+* googletest: Used for unit testing
 
 ### `pico`
 All RP2040 dependent code is included in this directory. Basically
 all peripheral access. It also includes configuration for RTOS.
 
+### `src`
+This is platform independent code, ideally all business logic should be found here. This makes it possible to build
+and test said logic in targets other than the original RP2040 processor.
+
+### `tests`
+This folder contains all tests for business logic code units, found in `src`. Said tests and
+the business logic tested are built using the host's compiler (generally amd64) and run in the host. These tests
+are automatically run on CI pipelines.
+
 ## Building
 This is a standard CMake project and can be built as such. The project is built and tested with
 ARM GCC. Logging macros depend on `__FILE_NAME__` so the compiler must define this macro. GCC
 versions below 12.3 don't define it and won't be able to build the project.
+
+### Running Tests
+The variable `HOST_BUILD` determines whether the project will be built for an RP2040 target (cross compiling),
+or for the host's target (usually your dev machine). Tests are only run on host builds. The following snippet builds
+and runs the tests:
+
+```shell
+cmake -DHOST_BUILD=YES -B cmake-build-host
+make -C cmake-build-host
+make -C cmake-build-host ARGS="-V" test
+```

--- a/include/uid.h
+++ b/include/uid.h
@@ -1,0 +1,14 @@
+#ifndef PCROAST_UID_H
+#define PCROAST_UID_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+/**
+ * Read a 64 bit unique address and convert it to a hexadecimal string.
+ * @param uid Pointer to the starting address of the 64 bit UID (LSB)
+ * @param result Address to store the resulting string in. Must be at least 17 bytes long.
+ */
+void uid_to_str(uint8_t *uid, char *result);
+
+#endif  // PCROAST_UID_H

--- a/pico/CMakeLists.txt
+++ b/pico/CMakeLists.txt
@@ -2,5 +2,14 @@ add_executable(pcroast pcroast.c wifi.c st7735.c)
 pico_enable_stdio_usb(pcroast 0)
 pico_enable_stdio_uart(pcroast 1)
 
-target_link_libraries(pcroast pico_stdlib pico_cyw43_arch_lwip_sys_freertos FreeRTOS-Kernel-Heap4 ugfx st7735 hardware_spi)
+target_link_libraries(pcroast
+        pico_stdlib
+        pico_cyw43_arch_lwip_sys_freertos
+        FreeRTOS-Kernel-Heap4
+        ugfx
+        st7735
+        hardware_spi
+        hardware_flash
+        uid
+)
 pico_add_extra_outputs(pcroast)

--- a/pico/pcroast.c
+++ b/pico/pcroast.c
@@ -1,16 +1,20 @@
 #include <FreeRTOS.h>
 #include <gfx.h>
+#include <hardware/flash.h>
 #include <hardware/watchdog.h>
 #include <pico/cyw43_arch.h>
 #include <pico/stdlib.h>
 #include <task.h>
 
 #include "logging.h"
+#include "uid.h"
 #include "wifi.h"
 
 TaskHandle_t wifiTaskHandle;
 TaskHandle_t startupTaskHandle;
 TaskHandle_t blinkLedTaskHandle;
+
+static char unique_id[17];
 
 void vApplicationMallocFailedHook(void) { LOG_ERROR("malloc has failed"); }
 
@@ -76,6 +80,10 @@ void vLaunch() {
 }
 
 int main(void) {
+    uint8_t *uid = NULL;
+    flash_get_unique_id(uid);
+    uid_to_str(uid, unique_id);
+
     stdio_init_all();
     LOG_INFO("starting %s version %s", PROJECT_NAME, PROJECT_VERSION);
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_library(uid uid.c)

--- a/src/uid.c
+++ b/src/uid.c
@@ -1,0 +1,18 @@
+#include "uid.h"
+
+static const char nibble_hex_lut[16] = {'0', '1', '2', '3', '4', '5', '6', '7',
+                                        '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+
+void uid_to_str(uint8_t *uid, char *result) {
+    result[16] = '\0';
+    uint8_t nibble;
+    for (int idx = 14; idx > -1; idx -= 2) {
+        nibble = ((*uid) >> 4) & 0xF;
+        result[idx] = nibble_hex_lut[nibble];
+
+        nibble = (*uid) & 0xF;
+        result[idx + 1] = nibble_hex_lut[nibble];
+
+        uid++;
+    }
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,5 @@
+include(CTest)
+
+add_executable(test_uid test_uid.cpp)
+target_link_libraries(test_uid uid gtest_main)
+add_test(uid test_uid)

--- a/tests/test_uid.cpp
+++ b/tests/test_uid.cpp
@@ -1,0 +1,21 @@
+#include <gtest/gtest.h>
+
+extern "C" {
+#include "uid.h"
+}
+
+TEST(TestUid, UidToStr) {
+    char uid_str[17];
+
+    uint8_t uid[8] = {0x7A, 0x12, 0x78, 0x89, 0xFE, 0x7A, 0x0B, 0xE0};
+    std::fill_n(uid_str, 17, 1);
+
+    uid_to_str(uid, uid_str);
+    ASSERT_EQ("e00b7afe8978127a", std::string(uid_str));
+
+    uint8_t uid2[8] = {0x00, 0x67, 0xA4, 0x9F, 0x0F, 0x0E, 0xaa, 0x00};
+    std::fill_n(uid_str, 17, 0xFF);
+
+    uid_to_str(uid2, uid_str);
+    ASSERT_EQ("00aa0e0f9fa46700", std::string(uid_str));
+}


### PR DESCRIPTION
This commit adds support for reading the UID of a raspberry board (its flash UID) and converting it into a hex string. Said behavior is unit tested, so a setup to run unittests has also been added.