### PR TITLE
Add tests to GH Actions

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -50,3 +50,16 @@ jobs:
           cd build-release
           cmake ../
           make
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: build host
+        run: |
+          cmake -DHOST_BUILD=YES -B cmake-build-host
+          make -C cmake-build-host
+      - name: run tests
+        run: |
+          make -C cmake-build-host ARGS="-V" test


### PR DESCRIPTION
This commit adds a new job to run all tests for business logic, built and run on the host itself (instead of ARM target).