### PR TITLE
Add buzzer support

### DIFF
--- a/include/beeper.h
+++ b/include/beeper.h
@@ -1,0 +1,15 @@
+#ifndef PCROAST_BEEPER_H
+#define PCROAST_BEEPER_H
+
+#include <stdint.h>
+
+struct BeeperConfig {
+    uint8_t beeps  : 8;
+    uint16_t msOn  : 12;
+    uint16_t msOff : 12;
+};
+
+void beeper_parse(uint32_t value, struct BeeperConfig *config);
+uint32_t beeper_dump(const struct BeeperConfig *config);
+
+#endif  // PCROAST_BEEPER_H

--- a/pico/CMakeLists.txt
+++ b/pico/CMakeLists.txt
@@ -11,5 +11,7 @@ target_link_libraries(
         st7735
         hardware_spi
         max6675
+        hardware_pwm
+        beeper
 )
 pico_add_extra_outputs(pcroast)

--- a/pico/pinout.h
+++ b/pico/pinout.h
@@ -29,4 +29,10 @@
 #define SPI1_6675_MISO 12
 #define SPI1_TX 15  // Not used but need to be defined to a known GPIO
 
+#define STOP_BTN 22
+#define START_BTN 21
+#define BUZZER_GPIO 2
+#define BUZZER_PWM_SLICE 1
+#define BUZZER_PWM_CHANNEL 0
+
 #endif  // PCROAST_PINOUT_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_library(max6675 max6675.c)
+add_library(beeper beeper.c)

--- a/src/beeper.c
+++ b/src/beeper.c
@@ -1,0 +1,11 @@
+#include "beeper.h"
+
+void beeper_parse(uint32_t value, struct BeeperConfig *config) {
+    config->beeps = value;
+    config->msOn = (value >> 8) & 0x3FF;
+    config->msOff = (value >> 20);
+}
+
+uint32_t beeper_dump(const struct BeeperConfig *config) {
+    return ((config->msOff << 20) | (config->msOn << 8) | config->beeps);
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,3 +3,7 @@ include(CTest)
 add_executable(test_max6675 test_max6675.cpp)
 target_link_libraries(test_max6675 max6675 gtest_main)
 add_test(max6675 test_max6675)
+
+add_executable(test_beeper test_beeper.cpp)
+target_link_libraries(test_beeper beeper gtest_main)
+add_test(beeper test_beeper)

--- a/tests/test_beeper.cpp
+++ b/tests/test_beeper.cpp
@@ -1,0 +1,29 @@
+#include <gtest/gtest.h>
+
+extern "C" {
+#include "beeper.h"
+}
+
+class TestBeeper : public testing::Test {
+   protected:
+    struct BeeperConfig config;
+    struct BeeperConfig result;
+
+    void SetUp() override {
+        config = {0};
+        result = {0};
+    }
+};
+
+TEST_F(TestBeeper, ParseDump) {
+    config.beeps = 15;
+    config.msOn = 500;
+    config.msOff = 200;
+
+    uint32_t value = beeper_dump(&config);
+    beeper_parse(value, &result);
+
+    ASSERT_EQ(15, result.beeps);
+    ASSERT_EQ(500, result.msOn);
+    ASSERT_EQ(200, result.msOff);
+}


### PR DESCRIPTION
An RTOS task has been added to beep a buzzer. It uses a roughly 2kHz PWM signal to dive said buzzer. The amount of beeps and time on/off is set when notifying the task.