### PR TITLE
Add basic SSR control

### DIFF
--- a/pico/CMakeLists.txt
+++ b/pico/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(pcroast pcroast.c wifi.c st7735.c graphics.c temperature.c)
+add_executable(pcroast pcroast.c wifi.c st7735.c graphics.c temperature.c control.c)
 pico_enable_stdio_usb(pcroast 0)
 pico_enable_stdio_uart(pcroast 1)
 

--- a/pico/control.c
+++ b/pico/control.c
@@ -12,11 +12,11 @@ void vZeroCrossCallback(void) {
         return;
     }
 
-    zeroCrossEvents++;
     if (zeroCrossEvents == 99) {
         zeroCrossEvents = 0;
         gpio_put(SSR_CONTROL_GPIO, 1);
     } else if (zeroCrossEvents > dutyCycle) {
         gpio_put(SSR_CONTROL_GPIO, 0);
     }
+    zeroCrossEvents++;
 }

--- a/pico/control.c
+++ b/pico/control.c
@@ -1,0 +1,22 @@
+#include <hardware/gpio.h>
+
+#include "pinout.h"
+
+static volatile uint8_t dutyCycle = 100;
+static volatile uint32_t zeroCrossEvents = 0;
+
+void vZeroCrossCallback(void) {
+    if (gpio_get_irq_event_mask(ZERO_CROSS_GPIO) & (GPIO_IRQ_EDGE_RISE | GPIO_IRQ_EDGE_FALL)) {
+        gpio_acknowledge_irq(ZERO_CROSS_GPIO, GPIO_IRQ_EDGE_RISE | GPIO_IRQ_EDGE_FALL);
+    } else {
+        return;
+    }
+
+    zeroCrossEvents++;
+    if (zeroCrossEvents == 99) {
+        zeroCrossEvents = 0;
+        gpio_put(SSR_CONTROL_GPIO, 1);
+    } else if (zeroCrossEvents > dutyCycle) {
+        gpio_put(SSR_CONTROL_GPIO, 0);
+    }
+}

--- a/pico/os_tasks.h
+++ b/pico/os_tasks.h
@@ -7,7 +7,15 @@
 
 void vReadTemperatureTask(void *pvParameters);
 
-void vWifiTask(__unused void *pvParameters);
+void vWifiTask(void *pvParameters);
 void vNetifStatusCallback(struct netif *netif);
+
+/**
+ * Callback executed on edge rises and falls. These signify the oven's AC voltage has crossed
+ * the zero line. Used to set the oven's duty cycle accordingly.
+ * @param gpio GPIO that triggered the callback
+ * @param events List of events in said GPIO that triggered the callback.
+ */
+void vZeroCrossCallback(void);
 
 #endif  // PCROAST_OS_TASKS_H

--- a/pico/pinout.h
+++ b/pico/pinout.h
@@ -34,7 +34,8 @@
 #define BUZZER_GPIO 2
 #define BUZZER_PWM_SLICE 1
 
-#define ZERO_CROSS_GPIO 7
+#define ZERO_CROSS_GPIO 6
+
 #define SSR_CONTROL_GPIO 3
 
 #endif  // PCROAST_PINOUT_H

--- a/pico/pinout.h
+++ b/pico/pinout.h
@@ -33,6 +33,8 @@
 #define START_BTN 21
 #define BUZZER_GPIO 2
 #define BUZZER_PWM_SLICE 1
-#define BUZZER_PWM_CHANNEL 0
+
+#define ZERO_CROSS_GPIO 7
+#define SSR_CONTROL_GPIO 3
 
 #endif  // PCROAST_PINOUT_H


### PR DESCRIPTION
Basic functionality to control a SSR based on AC cycles has been added. Upon clicking the start button, the SSR GPIO is turned on/off based on the desired duty cycle. The duty cycle represents the amount of AC cycles to turn on the SSR. Said cycles are counted based on the square wave output of a zero cross detector.

This functionality uses GPIO IRQs, they are all set and run on cortex 0. This is important as `gpio_set_irq_enabled` enables IRQs only on the core the function was called from.