### PR TITLE
feat: support stop button

### DIFF
--- a/pico/control.c
+++ b/pico/control.c
@@ -40,9 +40,21 @@ static float targetTemperature = 0;
 
 extern TaskHandle_t controlReflowTaskHandle;
 
+static void clearControllerError() {
+    controller.error2 = 0;
+    controller.error1 = 0;
+    controller.error = 0;
+}
+
 void vStartControl() {
     LOG_INFO("ramp to soak");
+    clearControllerError();
     stage = RAMP_TO_SOAK;
+}
+
+void vStopControl() {
+    stage = IDLE;
+    gpio_put(SSR_CONTROL_GPIO, 0);
 }
 
 void vControlReflowTask(__unused void *pvParameters) {
@@ -63,10 +75,7 @@ void vControlReflowTask(__unused void *pvParameters) {
                 soakSeconds++;
                 if (soakSeconds >= lowTempProfile.soakTime) {
                     LOG_INFO("ramp to reflow");
-                    controller.error2 = 0;
-                    controller.error1 = 0;
-                    controller.error = 0;
-
+                    clearControllerError();
                     stage = RAMP_TO_REFLOW;
                 }
                 break;

--- a/pico/os_tasks.h
+++ b/pico/os_tasks.h
@@ -5,7 +5,14 @@
  * Collection of all tasks, timers or callbacks that run in the application.
  */
 
+/**
+ * The following three control tasks internally use the same variables.
+ * In a SMP environment care must be taken to synchronize access. The easiest is to
+ * ensure they only run on a certain core, this can be achieved with Free RTOS core affinity.
+ */
+
 void vStartControl();
+void vStopControl();
 void vControlReflowTask(void *pvParameters);
 void vReadTemperatureTask(void *pvParameters);
 


### PR DESCRIPTION
Reflow process can be stopped on a falling edge on GPIO 22. This falling edge is meant to come from a push button. Care must be taken to run control tasks on a single core since they all access the stage variable, this works as a crude but effective sync method.