### PR TITLE
feat: blink rapidly when wifi connection fails

### DIFF
--- a/pico/pcroast.c
+++ b/pico/pcroast.c
@@ -26,6 +26,7 @@ TaskHandle_t httpRequestTaskHandle;
 const struct BeeperConfig beeperStartup = {.beeps = 2, .msOn = 100, .msOff = 100};
 
 volatile uint8_t reflowStarted = false;
+volatile uint32_t blinkDelay = 1980;
 
 void startButtonCallback(void) {
     if (gpio_get_irq_event_mask(START_BTN) & GPIO_IRQ_EDGE_FALL) {
@@ -63,7 +64,7 @@ void vBlinkLedTask(__unused void *pvParameters) {
         cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, 1);
         vTaskDelay(pdMS_TO_TICKS(20));
         cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, 0);
-        vTaskDelay(pdMS_TO_TICKS(1980));
+        vTaskDelay(pdMS_TO_TICKS(blinkDelay));
     }
 }
 

--- a/pico/wifi.c
+++ b/pico/wifi.c
@@ -17,6 +17,8 @@ static char http_response_first_line[64];
 static char strIpAddress[16] = {0};
 static ip_addr_t api_addr;
 
+extern uint32_t blinkDelay;
+
 static void httpSend(struct tcp_pcb *tpcb, struct HttpRequest *request) {
     size_t payload_size;
 
@@ -92,8 +94,10 @@ void vWifiTask(__unused void *pvParameters) {
                 WIFI_SSID, WIFI_PSK, CYW43_AUTH_WPA2_AES_PSK, WIFI_TIMEOUT
             )) {
             LOG_WARNING("failed to connect");
+            blinkDelay = 300;
         } else {
             LOG_INFO("connected");
+            blinkDelay = 1980;
         }
     }
 }


### PR DESCRIPTION
Since you normally won't have an UART monitor plugged in, this LED makes it easier to know if the Pico was able to connect to the wifi or not during startup.